### PR TITLE
Enforce local context role detection in Learning Style block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Todas las modificaciones importantes del proyecto se documentarán en este archivo.
 
 ## [2.0.3] — 2026-01-18
-- El bloque ahora respeta el rol local del curso. Los administradores o gestores inscritos como estudiantes ahora verán la vista de estudiante (invitación al test) en lugar del dashboard de profesor.
+- Se eliminaron las comprobaciones redundantes de administrador (`is_siteadmin()`) en varias vistas clave, mejorando la detección correcta de roles locales (profesores vs estudiantes) y el sistema de permisos basado en capacidades.
 
 ## [2.0.2] — 2026-01-18
 - Opción para mostrar/ocultar las descripciones en el bloque principal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Todas las modificaciones importantes del proyecto se documentarán en este archi
 
 ## [2.0.3] — 2026-01-18
 - Se eliminaron las comprobaciones redundantes de administrador (`is_siteadmin()`) en varias vistas clave, mejorando la detección correcta de roles locales (profesores vs estudiantes) y el sistema de permisos basado en capacidades.
-
+- Se agrega negrilla en el titulo del bloque para mejorar la visibilidad.
+- 
 ## [2.0.2] — 2026-01-18
 - Opción para mostrar/ocultar las descripciones en el bloque principal.
 - Adición del gráfico radar en resultados detallados y acceso permitido a los estudiantes a esta vista.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Todas las modificaciones importantes del proyecto se documentarán en este archivo.
 
+## [2.0.3] — 2026-01-18
+- El bloque ahora respeta el rol local del curso. Los administradores o gestores inscritos como estudiantes ahora verán la vista de estudiante (invitación al test) en lugar del dashboard de profesor.
+
 ## [2.0.2] — 2026-01-18
 - Opción para mostrar/ocultar las descripciones en el bloque principal.
 - Adición del gráfico radar en resultados detallados y acceso permitido a los estudiantes a esta vista.

--- a/admin_view.php
+++ b/admin_view.php
@@ -33,7 +33,7 @@ if (!$DB->record_exists('block_instances', array('blockname' => 'learning_style'
 }
 
 // Friendly redirect for unauthorized users
-if (!has_capability('block/learning_style:viewreports', $context) && !is_siteadmin()) {
+if (!has_capability('block/learning_style:viewreports', $context)) {
     redirect(new moodle_url('/course/view.php', array('id' => $courseid)));
 }
 
@@ -53,11 +53,8 @@ if ($action === 'delete' && $userid && confirm_sesskey()) {
     if ($confirm) {
         // Privacy check
         $targetuser = $DB->get_record('user', array('id' => $userid), '*', MUST_EXIST);
-        if (!is_siteadmin() && (
-            !is_enrolled($context, $targetuser, 'block/learning_style:take_test', true)
-            || has_capability('block/learning_style:viewreports', $context, $userid)
-            || is_siteadmin($userid)
-        )) {
+        if (!is_enrolled($context, $targetuser, 'block/learning_style:take_test', true)
+            || has_capability('block/learning_style:viewreports', $context, $userid)) {
             redirect(new moodle_url('/course/view.php', array('id' => $courseid)));
         }
         

--- a/block_learning_style.php
+++ b/block_learning_style.php
@@ -130,8 +130,8 @@ class block_learning_style extends block_base
     /**
      * Check if user can view dashboard
      */
-    private function can_view_dashboard($context) {
-        return has_capability('block/learning_style:viewreports', $context);
+    private function can_view_dashboard($context, $userid = null) {
+        return has_capability('block/learning_style:viewreports', $context, $userid);
     }
 
     /**
@@ -280,7 +280,7 @@ class block_learning_style extends block_base
         ];
 
         // Agregar botones al final (después del dashboard) para profesores/administradores 
-        $is_teacher = has_capability('block/learning_style:viewreports', $context) || is_siteadmin();
+        $is_teacher = $this->can_view_dashboard($context);
         if ($is_teacher) {
             $template_data['show_buttons'] = true;
             $template_data['admin_url'] = (new moodle_url('/blocks/learning_style/admin_view.php', array('courseid' => $COURSE->id)))->out();
@@ -293,10 +293,8 @@ class block_learning_style extends block_base
             $filtered_student_ids = array();
             foreach ($student_ids as $candidateid) {
                 $candidateid = (int)$candidateid;
-                if (is_siteadmin($candidateid)) {
-                    continue;
-                }
-                if (has_capability('block/learning_style:viewreports', $context, $candidateid)) {
+                
+                if ($this->can_view_dashboard($context, $candidateid)) {
                     continue;
                 }
                 $filtered_student_ids[] = $candidateid;

--- a/block_learning_style.php
+++ b/block_learning_style.php
@@ -131,9 +131,7 @@ class block_learning_style extends block_base
      * Check if user can view dashboard
      */
     private function can_view_dashboard($context) {
-        return is_siteadmin()
-            || has_capability('block/learning_style:viewreports', $context)
-            || has_capability('moodle/course:viewhiddensections', $context);
+        return has_capability('block/learning_style:viewreports', $context);
     }
 
     /**

--- a/download_results.php
+++ b/download_results.php
@@ -44,9 +44,7 @@ $enrolled_ids = array_keys($enrolled_users);
 $student_ids = array();
 foreach ($enrolled_ids as $candidateid) {
     $candidateid = (int)$candidateid;
-    if (is_siteadmin($candidateid)) {
-        continue;
-    }
+    
     if (has_capability('block/learning_style:viewreports', $context, $candidateid)) {
         continue;
     }

--- a/templates/continue_test.mustache
+++ b/templates/continue_test.mustache
@@ -3,7 +3,7 @@
         <div style="text-align: center; margin: 0 auto;">
             {{{icon}}}
         </div>
-        <h6 class="mt-2 mb-1">{{#str}} pluginname, block_learning_style {{/str}}</h6>
+        <h6 class="mt-2 mb-1 font-weight-bold">{{#str}} pluginname, block_learning_style {{/str}}</h6>
         <small class="text-muted">{{#str}} discover_your_style, block_learning_style {{/str}}</small>
     </div>
 

--- a/templates/results.mustache
+++ b/templates/results.mustache
@@ -33,7 +33,7 @@
 
     <div class="text-center">
         <a href="{{summary_url}}" class="btn btn-sm" style="background: linear-gradient(135deg, #1567f9 0%, #0054ce 100%); border: none; color: #fff; width: 100%; font-weight: 500;">
-            <i class="fa fa-chart-bar"></i> {{#str}} see_full_results, block_learning_style {{/str}}
+            <i class="fa fa-eye"></i> {{#str}} see_full_results, block_learning_style {{/str}}
         </a>
     </div>
 </div>

--- a/templates/results.mustache
+++ b/templates/results.mustache
@@ -4,7 +4,7 @@
             {{{icon}}}
             <i class="fa fa-check text-primary" style="position: absolute; top: -6px; right: -9px; font-size: 1.4em; background: white; border-radius: 50%; line-height: 1; text-shadow: 0 1px 2px rgba(0,0,0,0.1);"></i>
         </div>
-        <h6 class="mt-2 mb-1">{{#str}} test_completed, block_learning_style {{/str}}</h6>
+        <h6 class="mt-2 mb-1 font-weight-bold">{{#str}} test_completed, block_learning_style {{/str}}</h6>
         <small class="text-muted">{{#str}} your_results_here, block_learning_style {{/str}}</small>
     </div>
 

--- a/templates/test_invitation.mustache
+++ b/templates/test_invitation.mustache
@@ -3,7 +3,7 @@
         <div style="text-align: center; margin: 0 auto;">
             {{{icon}}}
         </div>
-        <h6 class="mt-2 mb-1">{{#str}} pluginname, block_learning_style {{/str}}</h6>
+        <h6 class="mt-2 mb-1 font-weight-bold">{{#str}} pluginname, block_learning_style {{/str}}</h6>
         <small class="text-muted">{{#str}} discover_your_style, block_learning_style {{/str}}</small>
     </div>
 

--- a/version.php
+++ b/version.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Learning Style Block Major Update
- * Version 2.0.2 - Production Ready
+ * Version 2.0.3 - Production Ready
  *
  * @package    block_learning_style
  * @copyright  2026 Jairo Serrano, Yuranis Henriquez, Isaac Sanchez, Santiago Orejuela, Maria Valentina
@@ -10,8 +10,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2026011800; // YYYYMMDDXX (year, month, day, 2-digit version number).
+$plugin->version = 2026011801; // YYYYMMDDXX (year, month, day, 2-digit version number).
 $plugin->requires = 2022041900; // Moodle 4.0+
 $plugin->component = 'block_learning_style';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '2.0.2';
+$plugin->release = '2.0.3';

--- a/view_individual.php
+++ b/view_individual.php
@@ -27,15 +27,14 @@ if (!$DB->record_exists('block_instances', array('blockname' => 'learning_style'
 // Security: Check permissions and enrollment
 $is_own_results = ($USER->id == $userid);
 $can_view_reports = has_capability('block/learning_style:viewreports', $context);
-$is_siteadmin = is_siteadmin();
 
 // Basic access check: If not owner, not teacher, and not admin -> Kick out
-if (!$is_own_results && !$can_view_reports && !$is_siteadmin) {
+if (!$is_own_results && !$can_view_reports) {
     redirect(new moodle_url('/course/view.php', array('id' => $course->id)));
 }
 
 // Cross-course privacy check: If teacher (not admin/owner), ensure target user is in this course
-if (!$is_own_results && !$is_siteadmin && !is_enrolled($context, $user)) {
+if (!$is_own_results && !$can_view_reports && !is_enrolled($context, $user)) {
     redirect(new moodle_url('/course/view.php', array('id' => $course->id)));
 }
 


### PR DESCRIPTION
This PR addresses an issue where the Learning Style block would incorrectly identify a user's role based on global permissions (like Site Admin or `moodle/course:viewhiddensections`) rather than their specific enrollment in the current course.

Previously, an admin or manager enrolled as a student in a specific course would see the Teacher Dashboard and be unable to take the test.

### Changes
- Updated `can_view_dashboard` in `block_learning_style.php`.
- Removed checks for `is_siteadmin()` and generic `moodle/course:viewhiddensections`.
- Now strictly relies on `has_capability('block/learning_style:viewreports', $context)`, ensuring the local course context is respected.
- Bold in the main block title for consistency with the others

This aligns the behavior with the other blocks.